### PR TITLE
Fixed user ID detection.

### DIFF
--- a/js/ZeroMe.coffee
+++ b/js/ZeroMe.coffee
@@ -181,7 +181,7 @@ class ZeroMe extends ZeroFrame
 			@user.updateInfo(cb)
 			return false
 
-		Page.cmd "dbQuery", ["SELECT * FROM json WHERE cert_user_id = :cert_user_id AND user_name IS NOT NULL AND file_name = 'data.json'", {cert_user_id: @site_info.cert_user_id}], (res) =>
+		Page.cmd "dbQuery", ["SELECT * FROM json WHERE directory='data/users/#{@site_info.auth_address}' AND user_name IS NOT NULL AND file_name = 'data.json'", {cert_user_id: @site_info.cert_user_id}], (res) =>
 			if res?.length > 0
 				@log "Found row for user", res[0]
 				@user = new User({hub: res[0]["hub"], auth_address: @site_info.auth_address})


### PR DESCRIPTION
Fixed a login bug that occurs when two users have the same
cert_user_id. The correct approach is to use auth_address, which are
unique public keys, rather than the cert_user_id, which are assigned by
the ID site and may not be unique.